### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@ module.exports = {
                     extensions: ['.tsx'],
                 }],
 
+                // Allow using defaultProps at top of class declaration
+                'react/static-property-placement': ['error', 'static public field'],
+
+                // Allow prop spreading
+                'react/jsx-props-no-spreading': 'off',
+
                 // Not going to worry about keyboard navigation for now
                 'jsx-a11y/click-events-have-key-events': 'off',
                 'jsx-a11y/no-static-element-interactions': 'off',


### PR DESCRIPTION
This update allows us to use two rules:

1. It allows prop spreading so you can say `<App {...props} />`. See: [react/jsx-props-no-spreading](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md).

2. It allows the declaration of defaultProps within a class definition. This is the cleanest way and our accepted standard. See [react/static-property-placement](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md).