### PR TITLE
Ignore the extensions `.ts` and `.tsx` when importing them

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = {
         'indent': ['error', 4],
         'no-underscore-dangle': 'off',
         'import/no-unresolved': 'off',
+        'import/extensions': ['error', 'ignorePackages', {
+            ts: 'never',
+            tsx: 'never',
+        }],
         'jsx-closing-tag-location': 'off',
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
@@ -30,10 +34,13 @@ module.exports = {
         'no-useless-escape': 'off',
     },
     settings: {
-        'import/extensions': ['.js', '.jsx'],
+        'import/resolver': {
+            node: {
+                extensions: ['.ts', '.tsx', '.json'],
+            },
+        },
     },
     overrides: [
-
         // Allow this file to use quotes on all ESLint rules for consistency
         {
             'files': ['./index.js'],


### PR DESCRIPTION
When bumping _eslint-plugin-import_ from 2.18.2 to a higher version, it complains about imported modules not having extensions. You may see the failed pipeline runs from Account, Marketplace and Contributor Portal.

The issue has been reported in _eslint-plugin-import_. The solution is provided based on [this comment](https://github.com/benmosher/eslint-plugin-import/issues/1615#issuecomment-577500405).

Tested with Account. It works as expected.

Note: We've planned further improvements for merging the rules in different libraries (CS-964). Let's do that step-by-step and make this change first. The merging can be the next step.