### PR TITLE
Release v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/eslint-config",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/eslint-config",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "ESLint rules for use across Ultimaker web-based products",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
Update eslint rules so that `.ts` and `.tsx` can be imported without using an extension.