### PR TITLE
Upgrade packages and disable no-use-before-define for typescript files

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,9 @@ module.exports = {
                  * using named for the base component in tests, and default for connected/router
                  * component in the app-proper. */
                 'import/no-named-as-default': 'off',
+
+                // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
+                'no-use-before-define': 'off',
             },
             settings: {
 

--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
         "lint:fix": "eslint --ignore-pattern '!.eslintrc.js' --fix '**/{.,}*.js'"
     },
     "devDependencies": {
-        "@typescript-eslint/parser": "^4.15.1",
+        "@typescript-eslint/parser": "^4.15.2",
         "eslint": "^6.4.0",
-        "eslint-config-airbnb": "^18.0.1",
+        "eslint-config-airbnb": "^18.2.1",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.14.3",
         "typescript": "^4.2.2"
     },
     "peerDependencies": {
-        "@typescript-eslint/parser": "^4.15.1",
+        "@typescript-eslint/parser": "^4.15.2",
         "eslint": "^6.4.0",
-        "eslint-config-airbnb": "^18.0.1",
+        "eslint-config-airbnb": "^18.2.1",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.14.3",


### PR DESCRIPTION
When updating `typescript-eslint/parser` in our repo's we noticed a LOT of `'React' was used before it was defined  no-use-before-define` errors.
And it turns out we aren't the only ones...

In general it seems to boil down to disabling that rule for typescript files:
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md

Tested it with `yalc` and as expected the lint errors are gone. Though, I can't figure out if we can somehow enable this rule: `@typescript-eslint/no-use-before-define`