### PR TITLE
Stop error messages on react/default-props-match-prop-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = {
             tsx: 'never',
         }],
         'jsx-closing-tag-location': 'off',
+        'react/default-props-match-prop-types': 'off',
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
         'react/no-array-index-key': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/eslint-config",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ultimaker/eslint-config",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "ESLint rules for use across Ultimaker web-based products",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
Here we run into an error during linting in a dependabot update:

```
/usr/src/app/src/views/package_view/PackageDetails.tsx
  257:5  error  defaultProp "beta_features" has no corresponding propTypes declaration  react/default-props-match-prop-types

✖ 1 problem (1 error, 0 warnings)
```

https://github.com/Ultimaker/stardust-marketplace/pull/1180/checks?check_run_id=3674492310

We already have the typing specified, but `defaultProps` doesn't look at the connector and find out the correct typing. Therefore we turn the error message off.

```TypeScript
PackageDetails.defaultProps = {
    beta_features: [],
};

const mapStateToProps = (state: RootState) => ({
    beta_features: state.token?.beta_features,
});